### PR TITLE
Fix "Can not convert Null to DateTime"

### DIFF
--- a/Clients/GogWishlist.cs
+++ b/Clients/GogWishlist.cs
@@ -83,7 +83,7 @@ namespace IsThereAnyDeal.Services
                                             try
                                             {
                                                 JObject resultObjGame = JObject.Parse(ResultWeb);
-                                                ReleaseDate = (DateTime)resultObjGame["release_date"];
+                                                ReleaseDate = (DateTime)(resultObjGame["release_date"] ?? defult(DateTime));
                                                 Name = (string)resultObjGame["title"];
                                                 Capsule = "http:" + (string)resultObjGame["images"]["logo2x"];
 


### PR DESCRIPTION
Use `default(DateTime)` if `ReleaseDate` could not be found (is null)