### PR TITLE
#48 Price fetch fixes

### DIFF
--- a/source/Services/IsThereAnyDealApi.cs
+++ b/source/Services/IsThereAnyDealApi.cs
@@ -573,7 +573,7 @@ namespace IsThereAnyDeal.Services
                 int countString = 0;
                 foreach (Wishlist wishlist in wishlists)
                 {
-                    if (countString == 200)
+                    if (countString == 150)
                     {
                         plains.Add(plain);
                         countString = 0;
@@ -586,6 +586,11 @@ namespace IsThereAnyDeal.Services
 
                     if (!wishlist.itadGameInfos?.Keys?.Contains(DateTime.Now.ToString("yyyy-MM-dd")) ?? true)
                     {
+                        if (string.IsNullOrWhiteSpace(wishlist.Plain))
+                        {
+                            continue;
+                        }
+
                         if (plain == string.Empty)
                         {
                             plain += wishlist.Plain;
@@ -663,23 +668,20 @@ namespace IsThereAnyDeal.Services
                                             {
                                                 try
                                                 {
-                                                    if (dataObj.price_new != 0 && itadPrices.Where(x => x.price_new > 0).Count() > 1)
-                                                    { 
-                                                        dataCurrentPrice.Add(new ItadGameInfo
-                                                        {
-                                                            Name = wishlist.Name,
-                                                            StoreId = wishlist.StoreId,
-                                                            SourceId = wishlist.SourceId,
-                                                            Plain = wishlist.Plain,
-                                                            PriceNew = Math.Round(dataObj.price_new, 2),
-                                                            PriceOld = Math.Round(dataObj.price_old, 2),
-                                                            PriceCut = dataObj.price_cut,
-                                                            CurrencySign = settings.CurrencySign,
-                                                            ShopName = dataObj.shop.name,
-                                                            ShopColor = GetShopColor(dataObj.shop.name, settings.Stores),
-                                                            UrlBuy = dataObj.url
-                                                        });
-                                                    }
+                                                    dataCurrentPrice.Add(new ItadGameInfo
+                                                    {
+                                                        Name = wishlist.Name,
+                                                        StoreId = wishlist.StoreId,
+                                                        SourceId = wishlist.SourceId,
+                                                        Plain = wishlist.Plain,
+                                                        PriceNew = Math.Round(dataObj.price_new, 2),
+                                                        PriceOld = Math.Round(dataObj.price_old, 2),
+                                                        PriceCut = dataObj.price_cut,
+                                                        CurrencySign = settings.CurrencySign,
+                                                        ShopName = dataObj.shop.name,
+                                                        ShopColor = GetShopColor(dataObj.shop.name, settings.Stores),
+                                                        UrlBuy = dataObj.url
+                                                    });
                                                 }
                                                 catch (Exception ex)
                                                 {


### PR DESCRIPTION
# Problem
Some games are listed as "No data for selected store in settings" even when the data exists in isthereanydeal.com
![image](https://github.com/Lacro59/playnite-isthereanydeal-plugin/assets/17652035/b94873b7-2b0c-41b6-a928-cca81f4bbbf4)

Issue ticket #48 

# Issues
Identified several issues that cause it.
1. When querying prices from API we're fetching up to 200 plains. From my testing I've discovered that anything past 150'th plain gets omitted from the response.
1. After fetching this filter is applied:
```
if (dataObj.price_new != 0 && itadPrices.Where(x => x.price_new > 0).Count() > 1)
```
Which means that valid games don't get the data, like:
* games with 0 price. For example:

  ```
  {".meta":{"currency":"EUR"},"data":{"elderscrollsonline":{"list":[{"price_new":0,"price_old":19.99,"price_cut":100,"url":"https:\/\/store.epicgames.com\/p\/the-elder-scrolls-online?epic_creator_id=585fd9faadb3406ab9a0475bc1d24125&epic_game_id=27aa2ebdcda14b3bb8a669aab73ca55f","shop":{"id":"epic","name":"Epic Game Store"},"drm":["epic"]},{"price_new":19.99,"price_old":19.99,"price_cut":0,"url":"https:\/\/greenmangaming.sjv.io\/c\/2545989\/1281797\/15105?u=https%3A%2F%2Fwww.greenmangaming.com%2Fgames%2Fthe-elder-scrolls-online-pc%2F","shop":{"id":"greenmangaming","name":"GreenManGaming"},"drm":["teso"]}],"urls":{"game":"https:\/\/isthereanydeal.com\/#\/page:game\/info?plain=elderscrollsonline"}}}}
  ```
* games that have only 1 store listing (or if the user has configured to only list single store prices), For example:
  ```
     "battlebitremastered": {
      "list": [
        {
          "price_new": 14.79,
          "price_old": 14.79,
          "price_cut": 0,
          "url": "https://store.steampowered.com/app/671860/",
          "shop": {
            "id": "steam",
            "name": "Steam"
          },
          "drm": []
        }
      ],
      "urls": {
        "game": "https://isthereanydeal.com/#/page:game/info?plain=battlebitremastered"
      }
    }
    ```
# Solutions
1. Changed to fetch up to 150 plains
2. Removed the check. Could not figure out, why we have the check. If it's for invalid response data, then we should use nullable integers, instead of checking for 0. Also, could not see any invalid response data, so this check seems redundant.

# Additional
Some games in the wishlist come with empty `plain`. I'm not sure why that happens, but I've excluded these items from price fetching, since that ends up fetching irrelevant data (https://isthereanydeal.com/#/page:game/info?plain=)